### PR TITLE
Fixed FAWE(FastAsyncWorldEdit) Exploit crashing server.

### DIFF
--- a/src/dev/_2lstudios/exploitfixer/bukkit/listener/PacketReceiveListener.java
+++ b/src/dev/_2lstudios/exploitfixer/bukkit/listener/PacketReceiveListener.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import net.minecraft.server.v1_8_R3.PacketPlayInTabComplete;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -204,6 +205,16 @@ public class PacketReceiveListener implements Listener {
         }
 
         notificationsModule.addPacketDebug(String.valueOf(packetType));
+
+        if(packetType == PacketType.PacketPlayInTabComplete){
+            final PacketPlayInTabComplete tabComplete = (PacketPlayInTabComplete) packetWrapper.getPacket();
+            final String cursor = tabComplete.a();
+
+            if(cursor.startsWith("/") && (cursor.contains("for(") || (cursor.contains("{") && cursor.contains("}")))){
+                this.notificationsModule.debug(player.getName() + " Tried to crash server using FAWE(FastAsyncWorldEdit) Exploit");
+                event.setCancelled(true);
+            }
+        }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)

--- a/src/dev/_2lstudios/exploitfixer/bungee/listeners/ListenerInitializer.java
+++ b/src/dev/_2lstudios/exploitfixer/bungee/listeners/ListenerInitializer.java
@@ -25,6 +25,7 @@ public class ListenerInitializer {
         pluginManager.registerListener(plugin, new DisconnectListener(moduleManager));
         pluginManager.registerListener(plugin, new PluginMessageListener(moduleManager));
         pluginManager.registerListener(plugin, new PostLoginListener(moduleManager));
+        pluginManager.registerListener(plugin, new TabCompletionListener(moduleManager));
     }
 
     public void unregister() {

--- a/src/dev/_2lstudios/exploitfixer/bungee/listeners/TabCompletionListener.java
+++ b/src/dev/_2lstudios/exploitfixer/bungee/listeners/TabCompletionListener.java
@@ -1,0 +1,32 @@
+package dev._2lstudios.exploitfixer.bungee.listeners;
+
+import dev._2lstudios.exploitfixer.bungee.managers.ModuleManager;
+import dev._2lstudios.exploitfixer.shared.modules.NotificationsModule;
+import net.md_5.bungee.UserConnection;
+import net.md_5.bungee.api.event.TabCompleteEvent;
+import net.md_5.bungee.api.plugin.Listener;
+import net.md_5.bungee.event.EventHandler;
+import net.md_5.bungee.event.EventPriority;
+
+public class TabCompletionListener implements Listener {
+
+    private NotificationsModule notificationsModule;
+
+    TabCompletionListener(final ModuleManager moduleManager) {
+        this.notificationsModule = moduleManager.getNotificationsModule();
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onTabCompletion(TabCompleteEvent event){
+        if(!(event.getSender() instanceof UserConnection)) return;
+
+        final String cursor = event.getCursor();
+        if(cursor.startsWith("/") && (cursor.contains("for(") || (cursor.contains("{") && cursor.contains("}")))) {
+            final UserConnection sender = (UserConnection) event.getSender();
+
+            this.notificationsModule.debug(sender.getName() + " Tried to crash server using FAWE(FastAsyncWorldEdit) Exploit");
+            event.setCancelled(true);
+        }
+    }
+
+}


### PR DESCRIPTION
Required: FastAsyncWorldEdit
Usage:
	Copy and paste "/to for(i=0;i<256;i++){for(j=0;j<256;j++){for(k=0;k<256;k++){for(l=0;l<256;l++){ln(pi)}}}}"
	on chat and add SPACE, Click TAB button to crash server.

My fix:
	Blocks TabComplete packets that can crash the server using this method.

Note:
	I think this fix will not throw a false detections.