### PR TITLE
Prevent CommandBlock Payload exploits

### DIFF
--- a/src/dev/_2lstudios/exploitfixer/listener/PacketReceiveListener.java
+++ b/src/dev/_2lstudios/exploitfixer/listener/PacketReceiveListener.java
@@ -108,6 +108,12 @@ public class PacketReceiveListener implements Listener {
                         exploitUtil.cancelExploit(event, hamsterPlayer, player, reason, bookVls);
                         return;
                     }
+                } else if (tag.equals("MC|AdvCdm") && !player.isOp()) {
+                        final String reason = "[" + packetName + "|Command Block] " + playerName + " tried to send a " + tag
+                                + " CustomPayload packet without being op!";
+
+                        exploitUtil.cancelExploit(event, hamsterPlayer, player, reason, bookVls);
+                        return;
                 }
 
                 exploitPlayer.addVls(event, hamsterPlayer, packetsModule, packetsModule.getMultiplier(tag));


### PR DESCRIPTION
This ensures that players cannot send a command block payload without being op (Follows vanilla logic)